### PR TITLE
feat: migrate deprecated-types

### DIFF
--- a/src/components/AccordionPanel/AccordionPanel.stories.tsx
+++ b/src/components/AccordionPanel/AccordionPanel.stories.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions'
-import { Story } from '@storybook/react'
+import { StoryFn } from '@storybook/react'
 import React, { FC, useState } from 'react'
 import styled, { css } from 'styled-components'
 
@@ -89,7 +89,7 @@ const AccordionPanelController: FC = () => {
   )
 }
 
-export const AccordionStyle: Story = () => (
+export const AccordionStyle: StoryFn = () => (
   <Wrapper>
     <AccordionPanelBase>
       <AccordionPanel>
@@ -143,7 +143,7 @@ export const AccordionStyle: Story = () => (
 )
 AccordionStyle.storyName = 'Accordion style'
 
-export const ExpandedOptions: Story = () => (
+export const ExpandedOptions: StoryFn = () => (
   <Wrapper>
     <AccordionPanelBase>
       <AccordionPanel displayIcon={true} expandableMultiply={true}>
@@ -173,7 +173,7 @@ export const ExpandedOptions: Story = () => (
 )
 ExpandedOptions.storyName = 'Expanded options'
 
-export const Callback: Story = () => (
+export const Callback: StoryFn = () => (
   <Wrapper>
     <AccordionPanelBase>
       <AccordionPanel displayIcon={false} expandableMultiply={true} onClick={action('Clicked')}>
@@ -190,7 +190,7 @@ export const Callback: Story = () => (
   </Wrapper>
 )
 
-export const ChangeDefaultExpanded: Story = () => <AccordionPanelController />
+export const ChangeDefaultExpanded: StoryFn = () => <AccordionPanelController />
 ChangeDefaultExpanded.storyName = 'Change defaultExpanded'
 
 const Wrapper = styled.div`

--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions'
-import { Story } from '@storybook/react'
+import { StoryFn } from '@storybook/react'
 import * as React from 'react'
 import styled from 'styled-components'
 
@@ -13,7 +13,7 @@ export default {
   component: DatePicker,
 }
 
-export const All: Story = () => {
+export const All: StoryFn = () => {
   const [value, setValue] = React.useState<string>(new Date(2020, 0, 1).toDateString())
 
   return (

--- a/src/components/DropZone/DropZone.stories.tsx
+++ b/src/components/DropZone/DropZone.stories.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions'
-import { Story } from '@storybook/react'
+import { StoryFn } from '@storybook/react'
 import * as React from 'react'
 import styled, { css } from 'styled-components'
 
@@ -15,7 +15,7 @@ export default {
 
 const onSelectFiles = action('onSelectFiles')
 
-export const All: Story = () => (
+export const All: StoryFn = () => (
   <Group>
     <li>
       <Text>Default</Text>

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions'
-import { Story } from '@storybook/react'
+import { StoryFn } from '@storybook/react'
 import { userEvent, within } from '@storybook/testing-library'
 import * as React from 'react'
 import styled, { css } from 'styled-components'
@@ -145,7 +145,7 @@ export const ControllableDropdown = () => {
   )
 }
 
-const Template: Story = () => (
+const Template: StoryFn = () => (
   <Wrapper>
     <Legends>
       <li>

--- a/src/components/Experimental/SideMenu/SideMenu.stories.tsx
+++ b/src/components/Experimental/SideMenu/SideMenu.stories.tsx
@@ -1,4 +1,4 @@
-import { Story } from '@storybook/react'
+import { StoryFn } from '@storybook/react'
 import React from 'react'
 import styled, { css } from 'styled-components'
 
@@ -13,7 +13,7 @@ export default {
   },
 }
 
-export const Default: Story = () => (
+export const Default: StoryFn = () => (
   <Wrapper>
     <SideMenu>
       <SideMenu.Group name="基本設定">

--- a/src/components/FieldSet/FieldSet.stories.tsx
+++ b/src/components/FieldSet/FieldSet.stories.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions'
-import { Story } from '@storybook/react'
+import { StoryFn } from '@storybook/react'
 import * as React from 'react'
 import styled, { css } from 'styled-components'
 
@@ -16,7 +16,7 @@ export default {
   },
 }
 
-export const All: Story = () => {
+export const All: StoryFn = () => {
   const themes = useTheme()
 
   return (

--- a/src/components/FlashMessage/FlashMessage.stories.tsx
+++ b/src/components/FlashMessage/FlashMessage.stories.tsx
@@ -1,4 +1,4 @@
-import { Story } from '@storybook/react'
+import { StoryFn } from '@storybook/react'
 import * as React from 'react'
 import styled from 'styled-components'
 
@@ -21,7 +21,7 @@ export default {
   },
 }
 
-const Template: Story = (arg) => (
+const Template: StoryFn = (arg) => (
   <List>
     {messageTypes.map((messageType) => (
       <li key={messageType}>
@@ -66,7 +66,7 @@ Fade.args = { animation: 'fade' }
 export const None = Template.bind({})
 None.args = { animation: 'none' }
 
-export const Demo: Story = () => {
+export const Demo: StoryFn = () => {
   const [visible, setVisible] = React.useState<boolean>(true)
   const [autoClose, setAutoClose] = React.useState<boolean>(true)
   const [type, setType] = React.useState<Props['type']>('success')
@@ -175,7 +175,7 @@ const ListInner = () => {
   }
   return <Button onClick={handleClick}>Add message</Button>
 }
-export const FlashMessageList: Story = () => (
+export const FlashMessageList: StoryFn = () => (
   <FlashMessageListProvider>
     <ListInner />
   </FlashMessageListProvider>

--- a/src/components/Header/Header.stories.tsx
+++ b/src/components/Header/Header.stories.tsx
@@ -1,4 +1,4 @@
-import { Story } from '@storybook/react'
+import { StoryFn } from '@storybook/react'
 import React, { ComponentProps } from 'react'
 
 import { Button } from '../Button'
@@ -12,7 +12,7 @@ export default {
   component: Header,
 }
 
-export const All: Story = () => (
+export const All: StoryFn = () => (
   <Stack gap={0.25}>
     <Header />
     <Header tenants={[{ id: 'test', name: '株式会社SmartHR' }]}>

--- a/src/components/Loader/Loader.stories.tsx
+++ b/src/components/Loader/Loader.stories.tsx
@@ -1,4 +1,4 @@
-import { Story } from '@storybook/react'
+import { StoryFn } from '@storybook/react'
 import * as React from 'react'
 import styled, { css } from 'styled-components'
 
@@ -9,7 +9,7 @@ export default {
   component: Loader,
 }
 
-export const All: Story = () => (
+export const All: StoryFn = () => (
   <>
     <Wrapper>
       <Text>Primary</Text>

--- a/src/components/PageCounter/PageCounter.stories.tsx
+++ b/src/components/PageCounter/PageCounter.stories.tsx
@@ -1,4 +1,4 @@
-import { Story } from '@storybook/react'
+import { StoryFn } from '@storybook/react'
 import React, { ComponentProps } from 'react'
 
 import { Stack } from '../Layout'
@@ -10,7 +10,7 @@ export default {
   component: PageCounter,
 }
 
-const Template: Story<ComponentProps<typeof PageCounter>> = (props) => <PageCounter {...props} />
+const Template: StoryFn<ComponentProps<typeof PageCounter>> = (props) => <PageCounter {...props} />
 
 export const All = () => (
   <Stack>

--- a/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions'
-import { Story } from '@storybook/react'
+import { StoryFn } from '@storybook/react'
 import * as React from 'react'
 import styled from 'styled-components'
 
@@ -31,7 +31,7 @@ const graphOptions: Option[] = [
   { value: 'chartPie', ariaLabel: 'パイチャート', content: <FaChartPieIcon /> },
 ]
 
-export const All: Story = () => {
+export const All: StoryFn = () => {
   const [value1, setValue1] = React.useState<string | null>('departments')
   const [value2, setValue2] = React.useState<string | null>('both')
   const [value3, setValue3] = React.useState<string | null>('chartArea')

--- a/src/components/StatusLabel/StatusLabel.stories.tsx
+++ b/src/components/StatusLabel/StatusLabel.stories.tsx
@@ -1,4 +1,4 @@
-import { Story } from '@storybook/react'
+import { StoryFn } from '@storybook/react'
 import * as React from 'react'
 import styled, { css } from 'styled-components'
 
@@ -14,7 +14,7 @@ export default {
   },
 }
 
-export const All: Story = () => (
+export const All: StoryFn = () => (
   <WrapperStack>
     <Stack gap={0.5}>
       <dt>色の種類</dt>

--- a/src/components/TextLink/TextLink.stories.tsx
+++ b/src/components/TextLink/TextLink.stories.tsx
@@ -1,4 +1,4 @@
-import { Story } from '@storybook/react'
+import { StoryFn } from '@storybook/react'
 import React from 'react'
 import styled, { css } from 'styled-components'
 
@@ -14,7 +14,7 @@ export default {
   },
 }
 
-export const All: Story = () => (
+export const All: StoryFn = () => (
   <Wrapper>
     <li>
       <TextLink href="/" prefix={<FaFlagIcon />}>

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,4 +1,4 @@
-import { Story } from '@storybook/react'
+import { StoryFn } from '@storybook/react'
 import { userEvent } from '@storybook/testing-library'
 import * as React from 'react'
 import { useSyncExternalStore } from 'react'
@@ -27,7 +27,7 @@ const subscribeFullscreenChange = (callback: () => void) => {
 }
 const getFullscreenElement = () => document.fullscreenElement
 
-const Template: Story = () => {
+const Template: StoryFn = () => {
   const fullscreenElementRef = React.useRef<HTMLDivElement>(null)
   const enterFullscreen = () => {
     if (fullscreenElementRef.current) {


### PR DESCRIPTION
## Related URL

- [Storybook Migration - ComponentStory, ComponentStoryObj, ComponentStoryFn and ComponentMeta types are deprecated](https://github.com/storybookjs/storybook/blob/eba6ed95048058333cc16716c5208f1eb1ffba2c/MIGRATION.md#componentstory-componentstoryobj-componentstoryfn-and-componentmeta-types-are-deprecated)

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

- Storybook 8 では使えなくなる古い型を更新したい

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- `npx storybook@next migrate upgrade-deprecated-types --glob="**/*.stories.tsx"`

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

n/a

<!--
Please attach a capture if it looks different.
-->
