### PR TITLE
feat: Migrate @storybook/addons

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@storybook/addon-interactions": "^7.6.17",
     "@storybook/addon-storysource": "^7.6.17",
     "@storybook/addon-styling": "^1.3.7",
-    "@storybook/addons": "^7.6.17",
     "@storybook/cli": "^7.6.17",
     "@storybook/jest": "^0.2.3",
     "@storybook/manager-api": "7.6.17",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@storybook/addons": "^7.6.17",
     "@storybook/cli": "^7.6.17",
     "@storybook/jest": "^0.2.3",
+    "@storybook/manager-api": "7.6.17",
     "@storybook/react": "^7.6.17",
     "@storybook/react-webpack5": "^7.6.17",
     "@storybook/source-loader": "^7.6.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ devDependencies:
   '@storybook/jest':
     specifier: ^0.2.3
     version: 0.2.3(jest@29.7.0)
+  '@storybook/manager-api':
+    specifier: 7.6.17
+    version: 7.6.17(react-dom@18.2.0)(react@18.2.0)
   '@storybook/react':
     specifier: ^7.6.17
     version: 7.6.17(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,9 +83,6 @@ devDependencies:
   '@storybook/addon-styling':
     specifier: ^1.3.7
     version: 1.3.7(@types/react-dom@18.2.23)(@types/react@18.2.55)(less@4.2.0)(postcss@8.4.38)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.3)(webpack@5.91.0)
-  '@storybook/addons':
-    specifier: ^7.6.17
-    version: 7.6.17(react-dom@18.2.0)(react@18.2.0)
   '@storybook/cli':
     specifier: ^7.6.17
     version: 7.6.17
@@ -3576,17 +3573,6 @@ packages:
     resolution: {integrity: sha512-sA0QCcf4QAMixWvn8uvRYPfkKCSl6JajJaAspoPqXSxHEpK7uwOlpg3kqFU5XJJPXD0X957M+ONgNvBzYqSpEw==}
     dependencies:
       memoizerific: 1.11.3
-    dev: true
-
-  /@storybook/addons@7.6.17(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-Ok18Y698Ccyg++MoUNJNHY0cXUvo8ETFIRLJk1g9ElJ70j6kPgNnzW2pAtZkBNmswHtofZ7pT156cj96k/LgfA==}
-    dependencies:
-      '@storybook/manager-api': 7.6.17(react-dom@18.2.0)(react@18.2.0)
-      '@storybook/preview-api': 7.6.17
-      '@storybook/types': 7.6.17
-    transitivePeerDependencies:
-      - react
-      - react-dom
     dev: true
 
   /@storybook/api@7.4.6(react-dom@18.2.0)(react@18.2.0):


### PR DESCRIPTION
## Related URL

[@storybook/addons \- npm](https://www.npmjs.com/package/@storybook/addons)

> This package will no longer be released as part of the 8.0 release of storybook.

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Storybook 8 ではサポートされなくなる `@storybook/addons` を移行したい。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

`@storybook/addons` を `@storybook/manager-api` に移行

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

n/a

<!--
Please attach a capture if it looks different.
-->
